### PR TITLE
Fix to resolve change to aggregator JSON format in KairosDB (Issue 1)

### DIFF
--- a/src/main/java/org/kairosdb/client/builder/QueryMetric.java
+++ b/src/main/java/org/kairosdb/client/builder/QueryMetric.java
@@ -18,6 +18,10 @@ package org.kairosdb.client.builder;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+import org.kairosdb.client.serializer.QueryMetricAggregateSerializer;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.kairosdb.client.util.Preconditions.checkNotNullOrEmpty;
 
@@ -33,6 +37,9 @@ public class QueryMetric
 {
 	private Map<String, String> tags = new LinkedHashMap<String, String>();
 	private String name;
+	
+	@JsonSerialize(using=QueryMetricAggregateSerializer.class)
+	@JsonProperty("aggregators")
 	private String aggregate;
 
 	QueryMetric(String name, String aggregator)

--- a/src/main/java/org/kairosdb/client/serializer/QueryMetricAggregateSerializer.java
+++ b/src/main/java/org/kairosdb/client/serializer/QueryMetricAggregateSerializer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 Proofpoint Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.kairosdb.client.serializer;
+
+import java.io.IOException;
+
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.SerializerProvider;
+
+public class QueryMetricAggregateSerializer extends JsonSerializer<String> {
+
+	/* (non-Javadoc)
+	 * @see org.codehaus.jackson.map.JsonSerializer#serialize(java.lang.Object, org.codehaus.jackson.JsonGenerator, org.codehaus.jackson.map.SerializerProvider)
+	 */
+	@Override
+	public void serialize(String value, 
+			JsonGenerator jgen,
+			SerializerProvider provider) throws IOException, JsonProcessingException 
+	{
+		jgen.writeStartArray();		
+		jgen.writeStartObject();
+		jgen.writeStringField("name", value);
+		jgen.writeEndObject();
+		jgen.writeEndArray();
+	}
+
+}

--- a/src/test/resources/query_multiple_metrics_relative_times.json
+++ b/src/test/resources/query_multiple_metrics_relative_times.json
@@ -1,1 +1,1 @@
-{"cacheTime":2000,"metrics":[{"tags":{"foo":"bar","larry":"moe"},"name":"metric1","aggregate":"sum"},{"tags":{"curly":"joe"},"name":"metric2","aggregate":"none"}],"start_relative":{"value":3,"unit":"WEEKS"},"end_relative":{"value":2,"unit":"DAYS"}}
+{"cacheTime":2000,"metrics":[{"tags":{"foo":"bar","larry":"moe"},"name":"metric1","aggregators":[{"name":"sum"}]},{"tags":{"curly":"joe"},"name":"metric2","aggregators":[{"name":"none"}]}],"start_relative":{"value":3,"unit":"WEEKS"},"end_relative":{"value":2,"unit":"DAYS"}}

--- a/src/test/resources/query_single_metric_absoluteStart_noEndTime_noTags.json
+++ b/src/test/resources/query_single_metric_absoluteStart_noEndTime_noTags.json
@@ -1,1 +1,1 @@
-{"metrics":[{"tags":{},"name":"metric1","aggregate":"sum"}],"start_absolute":1359799327000}
+{"metrics":[{"tags":{},"name":"metric1","aggregators":[{"name":"sum"}]}],"start_absolute":1359799327000}


### PR DESCRIPTION
Updated the query builder generation of the appropriate JSON for the
aggregates required for a metric. This is the bare minimum change to
support the new format, it does not allow for multiple aggregates per
metric.
