### PR TITLE
Added alignment parameters to aggregators

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.kairos</groupId>
     <artifactId>client</artifactId>
-    <version>2.0</version>
+    <version>2.0.1</version>
     <packaging>jar</packaging>
 
     <name>kairosclient</name>

--- a/src/main/java/org/kairosdb/client/builder/aggregator/SamplingAggregator.java
+++ b/src/main/java/org/kairosdb/client/builder/aggregator/SamplingAggregator.java
@@ -15,6 +15,7 @@
  */
 package org.kairosdb.client.builder.aggregator;
 
+import com.google.gson.annotations.SerializedName;
 import org.kairosdb.client.builder.Aggregator;
 import org.kairosdb.client.builder.TimeUnit;
 
@@ -24,6 +25,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class SamplingAggregator extends Aggregator
 {
 	private Sampling sampling;
+
+	@SerializedName("align_start_time")
+	private Boolean alignStartTime;
+
+	@SerializedName("align_sampling")
+	private Boolean alignSampling;
 
 	public SamplingAggregator(String name, int value, TimeUnit unit)
 	{
@@ -41,6 +48,24 @@ public class SamplingAggregator extends Aggregator
 	public TimeUnit getUnit()
 	{
 		return sampling.unit;
+	}
+
+	public SamplingAggregator withAlignment(Boolean alignStartTime, Boolean alignSampling)
+	{
+		this.alignStartTime = alignStartTime;
+		this.alignSampling = alignSampling;
+
+		return this;
+	}
+
+	public Boolean isAlignStartTime()
+	{
+		return alignStartTime;
+	}
+
+	public Boolean isAlignSampling()
+	{
+		return alignSampling;
 	}
 
 	private class Sampling

--- a/src/main/java/org/kairosdb/client/deserializer/ResultsDeserializer.java
+++ b/src/main/java/org/kairosdb/client/deserializer/ResultsDeserializer.java
@@ -55,7 +55,6 @@ public class ResultsDeserializer implements JsonDeserializer<Results>
 					type = ((DefaultGroupResult) groupResult).getType();
 				}
 			}
-System.out.println("******************* Type=" + type);
 			checkState(type != null, "Missing type");
 
 			// Data points

--- a/src/test/java/org/kairosdb/client/ClientIntegrationTest.java
+++ b/src/test/java/org/kairosdb/client/ClientIntegrationTest.java
@@ -335,6 +335,11 @@ public class ClientIntegrationTest
 			metric.addAggregator(AggregatorFactory.createMaxAggregator(1, TimeUnit.SECONDS));
 			metric.addAggregator(AggregatorFactory.createMinAggregator(1, TimeUnit.SECONDS));
 
+			metric.addAggregator(AggregatorFactory.createMaxAggregator(1, TimeUnit.SECONDS)
+					.withAlignment(false, false));
+			metric.addAggregator(AggregatorFactory.createMinAggregator(1, TimeUnit.SECONDS)
+					.withAlignment(true, true));
+
 			metric.addGrouper(new TagGrouper(HTTP_TAG_NAME_1, HTTP_TAG_NAME_2));
 			metric.addGrouper(new TimeGrouper(new RelativeTime(1, TimeUnit.MILLISECONDS), 3));
 			metric.addGrouper(new ValueGrouper(4));

--- a/src/test/java/org/kairosdb/client/InMemoryKairosServer.java
+++ b/src/test/java/org/kairosdb/client/InMemoryKairosServer.java
@@ -1,20 +1,12 @@
 package org.kairosdb.client;
 
-import com.google.inject.Binder;
-import com.google.inject.Module;
-import com.google.inject.Singleton;
 import org.apache.commons.io.FileUtils;
-import org.kairosdb.core.DataPoint;
-import org.kairosdb.core.DataPointListener;
 import org.kairosdb.core.Main;
 import org.kairosdb.core.exception.DatastoreException;
 import org.kairosdb.core.exception.KairosDBException;
-import sun.reflect.generics.scope.Scope;
-import sun.security.pkcs11.Secmod;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.SortedMap;
 
 public class InMemoryKairosServer extends Thread
 {

--- a/src/test/java/org/kairosdb/client/builder/QueryBuilderTest.java
+++ b/src/test/java/org/kairosdb/client/builder/QueryBuilderTest.java
@@ -184,6 +184,22 @@ public class QueryBuilderTest
 	}
 
 	@Test
+	public void test_SingleMetricAggregatorWithAlignment() throws IOException
+	{
+		String json = Resources.toString(
+				Resources.getResource("query_single_metric_aggregator_with_alignment.json"), Charsets.UTF_8);
+
+		QueryBuilder builder = QueryBuilder.getInstance();
+		builder.setStart(new Date(1359774127000L))
+				.setEnd(new Date(13597745127000L))
+				.addMetric("metric1")
+				.addAggregator(AggregatorFactory.createMaxAggregator(1, TimeUnit.DAYS)
+						.withAlignment(true, true));
+
+		assertThat(builder.build(), equalTo(json));
+	}
+
+	@Test
 	public void test_WithGroupBy() throws IOException
 	{
 		String json = Resources.toString(Resources.getResource("query_withGroupBys.json"), Charsets.UTF_8);

--- a/src/test/resources/query_single_metric_aggregator_with_alignment.json
+++ b/src/test/resources/query_single_metric_aggregator_with_alignment.json
@@ -1,0 +1,1 @@
+{"start_absolute":1359774127000,"end_absolute":13597745127000,"cacheTime":0,"metrics":[{"name":"metric1","tags":{},"group_by":[],"aggregators":[{"sampling":{"value":1,"unit":"DAYS"},"align_start_time":true,"align_sampling":true,"name":"max"}]}]}


### PR DESCRIPTION
This pull request contains changes which I did to fix the issue https://github.com/kairosdb/kairosdb-client/issues/18 (which I submitted): it brings to kairosdb client ability to set parameters "align sampling" and "align start time" on aggregators - these parameters were introduced in KairosDB 0.9.4.