### PR TITLE
Fixed compliation error becaus of package sun.security.pkcs11 that is no...

### DIFF
--- a/src/test/java/org/kairosdb/client/InMemoryKairosServer.java
+++ b/src/test/java/org/kairosdb/client/InMemoryKairosServer.java
@@ -10,7 +10,6 @@ import org.kairosdb.core.Main;
 import org.kairosdb.core.exception.DatastoreException;
 import org.kairosdb.core.exception.KairosDBException;
 import sun.reflect.generics.scope.Scope;
-import sun.security.pkcs11.Secmod;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
Fixed compliation error because of package sun.security.pkcs11 that is not part of 32-bit Oracle JDK on Windows platform... Removing the package apparently did not break any test.