### PR TITLE
Fix missing type results deserializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.kairosdb</groupId>
     <artifactId>client</artifactId>
-    <version>2.0</version>
+    <version>2.0-ZAL-1</version>
     <packaging>jar</packaging>
 
     <name>kairosclient</name>

--- a/src/main/java/org/kairosdb/client/builder/QueryBuilder.java
+++ b/src/main/java/org/kairosdb/client/builder/QueryBuilder.java
@@ -34,11 +34,11 @@ import static org.kairosdb.client.util.Preconditions.checkNotNullOrEmpty;
 
 /**
  * Builder used to create the JSON to query KairosDB.
- * <p/>
+ * <p>
  * The query returns the data points for the given metrics for the specified time range. The time range can
  * be specified as absolute or relative. Absolute times are a given point in time. Relative times are relative to now.
  * The end time is not required and defaults to now.
- * <p/>
+ * </p>
  * For example, if you specify a relative start time of 30 minutes, all matching data points for the last 30 minutes
  * will be returned. If you specify a relative start time of 30 minutes and a relative end time of 10 minutes, then
  * all matching data points that occurred between the last 30 minutes up to and including the last 10 minutes are returned.

--- a/src/main/java/org/kairosdb/client/builder/QueryMetric.java
+++ b/src/main/java/org/kairosdb/client/builder/QueryMetric.java
@@ -28,16 +28,16 @@ import static org.kairosdb.client.util.Preconditions.checkNotNullOrEmpty;
 /**
  * Query request for a metric. If a metric is queried by name only then all data points for all tags are returned.
  * You can narrow down the query by adding tags so only data points associated with those tags are returned.
- * <p/>
+ * <p>
  * Aggregators may be added to the metric. An aggregator performs an operation on the data such as summing or averaging.
  * If multiple aggregators are added, the output of the first is sent to the input of the next, and so forth until all
  * aggregators have been processed, These are processed in the order they were added.
- * <p/>
- * <p/>
+ * </p>
+ * <p>
  * The results of the query can be grouped in various ways using a grouper. For example, if you had a metric with a
  * customer tag, the resulting data points could be grouped by the different customers. Multiple groupers can be used
  * so you could, for example, group by tag and value.
- * <p/>
+ * </p>
  * Note that aggregation is very fast but grouping can slow down the query.
  */
 @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")

--- a/src/main/java/org/kairosdb/client/deserializer/ResultsDeserializer.java
+++ b/src/main/java/org/kairosdb/client/deserializer/ResultsDeserializer.java
@@ -55,11 +55,9 @@ public class ResultsDeserializer implements JsonDeserializer<Results>
 					type = ((DefaultGroupResult) groupResult).getType();
 				}
 			}
-System.out.println("******************* Type=" + type);
-			checkState(type != null, "Missing type");
 
 			// Data points
-			final Class dataPointValueClass = client.getDataPointValueClass(type);
+			final Class dataPointValueClass = type == null ? Double.class : client.getDataPointValueClass(type);
 			checkState(dataPointValueClass != null, "type: " + type + " is not registered to a custom data type.");
 
 			JsonArray array = (JsonArray) json.getAsJsonObject().get("values");


### PR DESCRIPTION
KairosDB Client should not fail for non-custom types. The fix simply deserializes the value (number) as "Double" instead of aborting with "missing type".