### PR TITLE
Query builder add a QueryMetric object

### DIFF
--- a/src/main/java/org/kairosdb/client/builder/QueryBuilder.java
+++ b/src/main/java/org/kairosdb/client/builder/QueryBuilder.java
@@ -96,6 +96,12 @@ public class QueryBuilder extends AbstractQueryBuilder<QueryBuilder>
 		return metric;
 	}
 
+	public QueryMetric addMetric(QueryMetric metric)
+	{
+		metrics.add(metric);
+		return metric;
+	}
+
 	/**
 	 * Returns the cache time.
 	 *

--- a/src/main/java/org/kairosdb/client/builder/QueryBuilder.java
+++ b/src/main/java/org/kairosdb/client/builder/QueryBuilder.java
@@ -95,7 +95,13 @@ public class QueryBuilder extends AbstractQueryBuilder<QueryBuilder>
 		metrics.add(metric);
 		return metric;
 	}
-
+	
+	/**
+	* Adds a QueryMetric object to the QueryBuilder
+	*
+	* @param metric a QueryMetric object
+	* @return the builder
+	*/
 	public QueryMetric addMetric(QueryMetric metric)
 	{
 		metrics.add(metric);

--- a/src/main/java/org/kairosdb/client/builder/QueryMetric.java
+++ b/src/main/java/org/kairosdb/client/builder/QueryMetric.java
@@ -82,7 +82,7 @@ public class QueryMetric
 
 	private Order order;
 
-	QueryMetric(String name)
+	public QueryMetric(String name)
 	{
 		this.name = checkNotNullOrEmpty(name);
 	}


### PR DESCRIPTION
This PR adds the ability to add a QueryMetric object directly to a QueryBuilder rather than have QueryBuilder create one for you - 

```
QueryBuilder builder = QueryBuilder.getInstance();
QueryMetric metric = new QueryMetric("cpu.idle");
metric.addAggregator(AggregatorFactory.createAverageAggregator(5, TimeUnit.MINUTES));
Grouper grouper = new TagGrouper("host");
metric.addGrouper(grouper);
builder.addMetric(metric);
```