### PR TITLE
Issue #64. Added support for filter aggregator.

### DIFF
--- a/src/main/java/org/kairosdb/client/builder/AggregatorFactory.java
+++ b/src/main/java/org/kairosdb/client/builder/AggregatorFactory.java
@@ -15,10 +15,9 @@
  */
 package org.kairosdb.client.builder;
 
-import org.kairosdb.client.builder.aggregator.CustomAggregator;
-import org.kairosdb.client.builder.aggregator.PercentileAggregator;
-import org.kairosdb.client.builder.aggregator.RateAggregator;
-import org.kairosdb.client.builder.aggregator.SamplingAggregator;
+import org.kairosdb.client.builder.aggregator.*;
+
+import javax.annotation.Nonnull;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -304,4 +303,10 @@ public class AggregatorFactory
 		checkNotNull(trim, "trim cannot be null");
 		return new CustomAggregator("trim", "\"trim\":\"" + trim + "\"");
 	}
+
+    public static FilterAggregator createFilterAggregator(@Nonnull FilterAggregator.Operation operation, double val) {
+		checkNotNull(operation, "operation cannot be null");
+		return new FilterAggregator(operation, val);
+    }
+
 }

--- a/src/main/java/org/kairosdb/client/builder/aggregator/FilterAggregator.java
+++ b/src/main/java/org/kairosdb/client/builder/aggregator/FilterAggregator.java
@@ -22,7 +22,7 @@ public class FilterAggregator extends Aggregator {
 
     public enum Operation
     {
-        LTE("lte"), LT("lt"), GTE("gte"), GT("gt"), EQUAL("eq");
+        LTE("lte"), LT("lt"), GTE("gte"), GT("gt"), EQUAL("equal");
 
         private String text;
 

--- a/src/main/java/org/kairosdb/client/builder/aggregator/FilterAggregator.java
+++ b/src/main/java/org/kairosdb/client/builder/aggregator/FilterAggregator.java
@@ -1,0 +1,43 @@
+package org.kairosdb.client.builder.aggregator;
+
+import com.google.gson.annotations.SerializedName;
+import org.kairosdb.client.builder.Aggregator;
+
+import java.util.Objects;
+
+public class FilterAggregator extends Aggregator {
+
+    @SerializedName("filter_op")
+    private String op;
+    @SerializedName("threshold")
+    private String threshold;
+
+    private static final transient String FILTER = "filter";
+
+    public FilterAggregator(Operation operation, double threshold) {
+        super(FILTER);
+        this.op = operation.getText();
+        this.threshold = Objects.toString(threshold);
+    }
+
+    public enum Operation
+    {
+        LTE("lte"), LT("lt"), GTE("gte"), GT("gt"), EQUAL("eq");
+
+        private String text;
+
+        Operation(String text) {this.text = text;}
+
+        private String getText() {
+            return text;
+        }
+    }
+
+    public String getOperation() {
+        return op;
+    }
+
+    public String getThreshold() {
+        return threshold;
+    }
+}

--- a/src/test/java/org/kairosdb/client/builder/AggregatorFactoryTest.java
+++ b/src/test/java/org/kairosdb/client/builder/AggregatorFactoryTest.java
@@ -1,10 +1,7 @@
 package org.kairosdb.client.builder;
 
 import org.junit.Test;
-import org.kairosdb.client.builder.aggregator.CustomAggregator;
-import org.kairosdb.client.builder.aggregator.PercentileAggregator;
-import org.kairosdb.client.builder.aggregator.RateAggregator;
-import org.kairosdb.client.builder.aggregator.SamplingAggregator;
+import org.kairosdb.client.builder.aggregator.*;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -205,4 +202,14 @@ public class AggregatorFactoryTest
 		assertThat(aggregator.getName(), equalTo("sma"));
 		assertThat(aggregator.toJson(), equalTo("{\"name\":\"sma\",'size':5}"));
 	}
+
+	@Test
+	public void test_createFilterAggregator() {
+		FilterAggregator filter = AggregatorFactory.createFilterAggregator(FilterAggregator.Operation.EQUAL, 1d);
+
+		assertThat(filter.getName(), equalTo("filter"));
+		assertThat(filter.getOperation(), equalTo("eq"));
+		assertThat(filter.getThreshold(), equalTo("1.0"));
+	}
+
 }


### PR DESCRIPTION
Added filter aggregator. However, unable to fix the issue https://github.com/kairosdb/kairosdb/issues/424 where the EQUALS filter is not working in Kairosdb 1.1.3.