### PR TITLE
do not process content if NO_CONTENT response was received

### DIFF
--- a/src/main/java/org/kairosdb/client/response/DefaultJsonResponseHandler.java
+++ b/src/main/java/org/kairosdb/client/response/DefaultJsonResponseHandler.java
@@ -71,6 +71,9 @@ public class DefaultJsonResponseHandler<T> implements JsonResponseHandler
 					request,
 					response);
 		}
+		if (response.getStatusCode() == 204) {
+			return null;
+		}
 		String contentType = response.getHeader(CONTENT_TYPE);
 		if (contentType == null)
 		{


### PR DESCRIPTION
I'm testing the new client version 3.0.0 and stumbled upon a problem when pushing metrics.

### Environment
First of all, one important information: I'm _not connecting directly to a K* instance_. Instead there's some kind of _gateway_ we've implemented in order to be able to do some more stuff with ingested metrics, i.e. analyze them seperately. Thus, _the gateway is producing the response here_.

### Problem
Now, here's the thing: the client checks the response content even if the response status code is 204 (NO_CONTENT). IMHO, this doesn't make sense; furthermore, this leads to exceptions in our code because the gateway correctly sends **204 without content**.
Again: this problem might not orrur when directly communicating with a K* instance because it sends content. But strictly speaking it just doesn't make sense...

### Proposal
With this pull request's changes, the client simply returns from the `handle` method if the response status code is 204, effectively skipping any content evaluation. There may be a better solution for this, but it works for me right now.