### PR TITLE
修复GZIP压缩传输时，中文解码错误的bug

### DIFF
--- a/src/main/java/org/kairosdb/client/HttpClient.java
+++ b/src/main/java/org/kairosdb/client/HttpClient.java
@@ -280,7 +280,7 @@ public class HttpClient implements Client
 		{
 			request = new Request(createURI(path), "POST",
 					ImmutableListMultimap.of(CONTENT_TYPE, APPLICATION_GZIP),
-					new StringBodySource(json, TEXT_PLAIN, true));
+					new StringBodySource(json, ContentType.create(TEXT_PLAIN.getMimeType(), "UTF-8"), true));
 		}
 		else
 		{


### PR DESCRIPTION
修复开启压缩时builder.setCompression(true)，KairosDB Server将无法解码中文的bug