### PR TITLE
DefaultJsonResponseHandler use UTF-8

### DIFF
--- a/src/main/java/org/kairosdb/client/response/DefaultJsonResponseHandler.java
+++ b/src/main/java/org/kairosdb/client/response/DefaultJsonResponseHandler.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
@@ -92,7 +93,7 @@ public class DefaultJsonResponseHandler<T> implements JsonResponseHandler
 				return null;
 			}
 
-			reader = new InputStreamReader(response.getInputStream());
+			reader = new InputStreamReader(response.getInputStream(), StandardCharsets.UTF_8);
 
 			if (response.getStatusCode() == 400)
 			{


### PR DESCRIPTION
Kairosdb rest services returns UTF-8
Example org.kairosdb.core.http.rest.MetricsResource:
`@OPTIONS
@Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
@Path("/datapoints")`